### PR TITLE
Store action masks in PPO rollout

### DIFF
--- a/training/scripts/train.py
+++ b/training/scripts/train.py
@@ -70,6 +70,7 @@ def main():
         rollout_length=rollout_length,
         num_envs=1,
         obs_shape=obs.shape,
+        action_dim=action_dim,
         hidden_size=policy.lstm_hidden,
         num_layers=policy.lstm.num_layers,
     ).to(device)
@@ -105,6 +106,7 @@ def main():
                 dones=done_t.detach().cpu(),
                 h_pre=h_pre.detach().cpu(),
                 c_pre=c_pre.detach().cpu(),
+                action_masks=mask.detach().cpu(),
             )
 
             obs_t = obs_next_t


### PR DESCRIPTION
## Summary
- extend PPO rollout storage to keep per-step legal action masks
- plumb masks from env through training loop into learner update
- evaluate policy with masks so entropy respects legal actions

## Testing
- `pytest -q` *(fails: ImportError in tests/backend/test_engine.py)*
- `pytest training/tests -q` *(fails: environment-related assertions and missing config)*
- `python -m training.scripts.train --config training/configs/debug-fast.json`


------
https://chatgpt.com/codex/tasks/task_e_68ac9e1e7f2c832081cee9b702775af4