### PR TITLE
Reset rollout storage each PPO update

### DIFF
--- a/training/algorithms/ppo_lstm/storage.py
+++ b/training/algorithms/ppo_lstm/storage.py
@@ -51,6 +51,28 @@ class RolloutStorage:
     def set_initial_obs(self, obs0: torch.Tensor):
         self.obs[0].copy_(obs0)
 
+    def reset(self):
+        """Reset internal buffers and step counter.
+
+        RolloutStorage accumulates data over a fixed-length buffer. When
+        starting a new rollout we want to clear any stale values from the
+        previous iteration and reset the write index.  This helper zeros all
+        stored tensors and sets ``step`` back to ``0`` so the next call to
+        :meth:`insert` starts writing from the beginning.
+        """
+        self.step = 0
+        self.obs.zero_()
+        self.actions.zero_()
+        self.log_probs.zero_()
+        self.rewards.zero_()
+        self.dones.zero_()
+        self.values.zero_()
+        self.h_pre.zero_()
+        self.c_pre.zero_()
+        self.h_last.zero_()
+        self.c_last.zero_()
+        self.returns.zero_()
+
     def insert(
         self,
         obs_next: torch.Tensor,

--- a/training/scripts/train.py
+++ b/training/scripts/train.py
@@ -76,12 +76,14 @@ def main():
 
     # Initialize
     obs_t = torch.tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)  # (1,C,H,W)
-    storage.set_initial_obs(obs_t)
     hidden = policy.init_hidden(batch_size=1)
 
     learner = PPOLearner(policy, ppo_cfg)
 
     for update in range(total_updates):
+        # Start a new rollout by clearing old data and setting the initial observation
+        storage.reset()
+        storage.set_initial_obs(obs_t)
         for t in range(rollout_length):
             mask = torch.tensor(info.get("legal_mask"), dtype=torch.float32, device=device).unsqueeze(0)
             h_pre, c_pre = hidden


### PR DESCRIPTION
## Summary
- add reset method to RolloutStorage to clear buffers and step counter
- call `reset()` and `set_initial_obs()` at start of each training update

## Testing
- `pytest training/tests -q` *(fails: dead cards, encodings, env_api, masks, sequences)*
- `python -m training.scripts.train --config training/configs/tiny-smoke.json --override '{"training.total_updates":3}'`


------
https://chatgpt.com/codex/tasks/task_e_68ac9e1f97548320ae0a29d0daa0a9f3